### PR TITLE
Update validate-readme.yml

### DIFF
--- a/.github/workflows/validate-readme.yml
+++ b/.github/workflows/validate-readme.yml
@@ -3,14 +3,14 @@ name: Validate README
 on:
   push:
     branches:
-      - "**"
+      - "main"
 
 permissions:
   contents: read
 
 concurrency:
   group: validate-readme-${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 jobs:
   validate:


### PR DESCRIPTION
## Summary by Sourcery

Restrict the README validation workflow to main branch pushes and enable cancellation of in-progress runs

CI:
- Limit the validate-readme workflow to run only on the main branch
- Enable cancel-in-progress to abort redundant workflow runs