### PR TITLE
Update deploy-testnets.yml

### DIFF
--- a/.github/workflows/deploy-testnets.yml
+++ b/.github/workflows/deploy-testnets.yml
@@ -2,7 +2,6 @@ name: Deploy testnets
 on:
   push:
     branches:
-            - master
             - main
             - dev
 permissions:
@@ -10,7 +9,7 @@ permissions:
 
 concurrency:
   group: deploy-testnets-${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 jobs:
   discover-matrix:
@@ -156,7 +155,6 @@ jobs:
           name: catapult-outputs-${{ matrix.networkName }}-${{ matrix.chainId }}
           path: outputs/**
           if-no-files-found: ignore
-
 
   dry-run:
     name: Catapult dry-run


### PR DESCRIPTION
## Summary by Sourcery

Update the deploy-testnets workflow to remove the master branch trigger and enable cancellation of in-progress runs

CI:
- Remove the master branch from the workflow's push triggers
- Enable cancel-in-progress in the workflow concurrency settings