### PR TITLE
Add packs implementation verification (#77)

### DIFF
--- a/jobs/builder/factories_v3.yaml
+++ b/jobs/builder/factories_v3.yaml
@@ -419,3 +419,36 @@ actions:
           types: ["address", "address"]
           values: ["{{developer-multisig-01}}", "{{erc1155-holder.address}}"]
     output: false
+
+  - name: "verify-erc1155-pack-implementation"
+    depends_on: ["verify-erc1155-pack-factory"]
+    template: "verify-contract"
+    arguments:
+      address:
+        type: "compute-create"
+        arguments:
+          deployerAddress: "{{erc1155-pack-factory.address}}"
+          nonce: "1"
+      contract: "{{Contract(./build-info/v2/ERC1155-Pack-factory.json:ERC1155Pack)}}"
+    output: false
+
+  - name: "verify-erc1155-pack-implementation-proxy"
+    depends_on: ["verify-erc1155-pack-implementation"]
+    template: "verify-contract"
+    arguments:
+      address:
+        type: "compute-create"
+        arguments:
+          deployerAddress: "{{erc1155-pack-factory.address}}"
+          nonce: "2"
+      contract: "{{Contract(./build-info/v2/ERC1155-Pack-factory.json:UpgradeableBeacon)}}"
+      constructorArguments:
+        type: "constructor-encode"
+        arguments:
+          types: ["address"]
+          values:
+            - type: "compute-create"
+              arguments:
+                deployerAddress: "{{erc1155-pack-factory.address}}"
+                nonce: "1"
+    output: false


### PR DESCRIPTION
## Summary by Sourcery

Add CI verification steps for ERC1155 Pack implementation and its proxy in the builder job definitions

CI:
- Add verify-erc1155-pack-implementation job to validate the deployed pack implementation contract
- Add verify-erc1155-pack-implementation-proxy job to validate the proxy contract with constructor arguments computed from the implementation address