### PR TITLE
Update deploy-mainnets.yml

### DIFF
--- a/.github/workflows/deploy-mainnets.yml
+++ b/.github/workflows/deploy-mainnets.yml
@@ -3,7 +3,6 @@ name: Deploy mainnets
 on:
   push:
     branches:
-      - master
       - main
   workflow_dispatch:
 


### PR DESCRIPTION
## Summary by Sourcery

Build:
- Adjust deploy-mainnets GitHub Actions workflow to stop triggering on the deprecated master branch.